### PR TITLE
fix: Resolve white screen issue by removing undefined prop

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -138,7 +138,6 @@ const Index = () => {
         focusState={focusState}
         isActive={isActive}
         micEnabled={micEnabled}
-        audioStream={audioStream}
         breathCoherence={breathCoherence}
         drrState={drrState}
         audioConfig={audioConfig}


### PR DESCRIPTION
This commit fixes a critical bug that caused a white screen to appear, preventing the application from rendering.

- The `audioStream` prop, which was undefined, has been removed from the `MainCanvas` component in `Index.tsx`.