### PR TITLE
fix: Resolve white screen issue by removing incorrect prop

### DIFF
--- a/src/components/MainCanvas.tsx
+++ b/src/components/MainCanvas.tsx
@@ -81,7 +81,6 @@ const MainCanvas: React.FC<MainCanvasProps> = ({
       <DRREngine
         isActive={isActive}
         micEnabled={micEnabled}
-        audioStream={audioStream}
         onDRRStateUpdate={onDRRStateUpdate}
         onResonanceUpdate={onResonanceUpdate}
         onAudioConfigUpdate={onAudioConfigUpdate}
@@ -96,7 +95,6 @@ const MainCanvas: React.FC<MainCanvasProps> = ({
         focusState={focusState}
         isActive={isActive}
         micEnabled={micEnabled}
-        audioStream={audioStream}
         drrState={drrState}
         audioConfig={audioConfig}
         creativeFlowState={creativeFlowState}


### PR DESCRIPTION
This commit fixes a critical bug that caused a white screen to appear, preventing the application from rendering.

- The `audioStream` prop, which was not defined in `MainCanvas.tsx`, has been removed from the `DRREngine` and `AudioEngine` components.